### PR TITLE
[CONSUL-705] Sync Nomad and Consul: Documentation

### DIFF
--- a/website/content/docs/job-specification/expose.mdx
+++ b/website/content/docs/job-specification/expose.mdx
@@ -136,6 +136,13 @@ job "expose-example" {
 - `path` <code>([Path]: nil)</code> - A list of [Envoy Expose Path Configurations][expose_path]
   to expose through Envoy.
 
+- `checks` `(bool: false)` - If enabled, all HTTP and gRPC checks registered with the agent are exposed through Envoy.
+  Envoy will expose listeners for these checks and will only accept connections originating from localhost
+  or Consul's [`advertise address`](/consul/docs/agent/config/config-files#advertise).
+  The port for these listeners are dynamically allocated from
+  [`expose_min_port`](/consul/docs/agent/config/config-files#expose_min_port)
+  to [`expose_max_port`](/consul/docs/agent/config/config-files#expose_max_port).
+
 ### `path` Parameters
 
 - `path` `(string: required)` - The HTTP or gRPC path to expose. The path must be prefixed

--- a/website/content/docs/job-specification/expose.mdx
+++ b/website/content/docs/job-specification/expose.mdx
@@ -133,7 +133,7 @@ job "expose-example" {
 
 ## `expose` Parameters
 
-- `path` <code>([Path]: nil)</code> - A list of [Envoy Expose Path Configurations][expose_path]
+- `path` <code>([Path]: nil)</code> - A list of [Envoy Expose Path Configurations][path]
   to expose through Envoy.
 
 - `checks` `(bool: false)` - If enabled, all HTTP and gRPC checks registered with the agent are exposed through Envoy.

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -178,6 +178,23 @@ envoy_gateway_bind_addresses "<service>" {
   to verify the gateway's authenticity. It must be provided if a `cert_file` is provided.
 - `sni` `(string: <optional>)` - An optional hostname or domain name to specify during
   the TLS handshake.
+- `request_headers` `(HTTPHeaderModifiers: <optional>)` - A set of HTTP-specific header modification rules that
+  will be applied to requests routed to this service. This cannot be used with a tcp listener.
+- `response_headers` `(HTTPHeaderModifiers: <optional>)` - A set of HTTP-specific header modification rules that 
+  will be applied to responses from this service. This cannot be used with a tcp listener.
+- `tls` `(ServiceTLSConfig: <optional>)` - TLS configuration for this service.
+
+  - `sds` `(SDSConfig: <optional>)` - Defines a set of parameters that configures the SDS source 
+  for the certificate for this specific service. At least one custom host must be specified in Hosts. 
+  The certificate retrieved from SDS will be served for all requests identifying one of the Hosts values 
+  in the TLS Server Name Indication (SNI) header.
+
+    - `cluster_name` `(string)` - The SDS cluster name to connect to to retrieve certificates.
+
+    - `cert_resource` `(string)` - The SDS resource name to request when fetching the certificate from the SDS service.
+- `max_connections` `(int: 0)` - overrides for the Defaults field
+- `max_pending_requests` `(int: 0)` - overrides for the Defaults field
+- `max_concurrent_requests` `(int: 0)` - overrides for the Defaults field
 
 ### `mesh` Parameters
 

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -95,19 +95,17 @@ envoy_gateway_bind_addresses "<service>" {
 - `meta` `(map<string|string>: nil)` - Specifies arbitrary KV metadata pairs.
 - `defaults` `(IngressServiceConfig: <optional>)` - Default configuration that applies to all upstreams.
 
-    - `max_connections` `(int: 0)` - The maximum number of connections a service instance will be allowed
-    to establish against the given upstream.
-    - `max_pending_requests` `(int: 0)` - The maximum number of requests that will be queued while waiting
-    for a connection to be established.
-    - `max_concurrent_requests` `(int: 0)` - The maximum number of concurrent requests that will be allowed
-    at a single point in time.
-    - `passive_health_check` `(PassiveHealthCheck: <optional>)` - Passive health checks remove hosts from
-    the upstream cluster that are unreachable or that return errors.
-
-        - `internal` `(int: <optional>)` - The time in nanosecond between checks.
-        - `max_failures` `(int: <optional>)` - The number of consecutive failures that cause a host to be
-        removed from the upstream cluster.
-        - `enforcing_consecutive_5xx` `(int: <optional>)` - A percentage representing the chance that a host
+  - `max_connections` `(int: 0)` - The maximum number of connections a service instance will be allowed
+  to establish against the given upstream.
+  - `max_pending_requests` `(int: 0)` - The maximum number of requests that will be queued while waiting
+  for a connection to be established.
+  - `max_concurrent_requests` `(int: 0)` - The maximum number of concurrent requests that will be allowed
+  at a single point in time.
+  - `passive_health_check` `(PassiveHealthCheck: <optional>)` - Passive health checks remove hosts from
+  the upstream cluster that are unreachable or that return errors.
+    - `internal` `(int: <optional>)` - The time in nanosecond between checks.
+    - `max_failures` `(int: <optional>)` - The number of consecutive failures that cause a host to be removed from the upstream cluster.
+    - `enforcing_consecutive_5xx` `(int: <optional>)` - A percentage representing the chance that a host
         will be actually ejected when the proxy detects an outlier status through consecutive errors in the 500 code range.
 
 #### `tls` Parameters

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -92,6 +92,23 @@ envoy_gateway_bind_addresses "<service>" {
 - `tls` <code>([tls]: nil)</code> - TLS configuration for this gateway.
 - `listener` <code>(array<[listener]> : required)</code> - One or more listeners that the
   ingress gateway should setup, uniquely identified by their port number.
+- `meta` `(map<string|string>: nil)` - Specifies arbitrary KV metadata pairs.
+- `defaults` `(IngressServiceConfig: <optional>)` - Default configuration that applies to all upstreams.
+
+    - `max_connections` `(int: 0)` - The maximum number of connections a service instance will be allowed
+    to establish against the given upstream.
+    - `max_pending_requests` `(int: 0)` - The maximum number of requests that will be queued while waiting
+    for a connection to be established.
+    - `max_concurrent_requests` `(int: 0)` - The maximum number of concurrent requests that will be allowed
+    at a single point in time.
+    - `passive_health_check` `(PassiveHealthCheck: <optional>)` - Passive health checks remove hosts from
+    the upstream cluster that are unreachable or that return errors.
+
+        - `internal` `(int: <optional>)` - The time in nanosecond between checks.
+        - `max_failures` `(int: <optional>)` - The number of consecutive failures that cause a host to be
+        removed from the upstream cluster.
+        - `enforcing_consecutive_5xx` `(int: <optional>)` - A percentage representing the chance that a host
+        will be actually ejected when the proxy detects an outlier status through consecutive errors in the 500 code range.
 
 #### `tls` Parameters
 

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -90,7 +90,7 @@ envoy_gateway_bind_addresses "<service>" {
 ### `ingress` Parameters
 
 - `tls` <code>([tls]: nil)</code> - TLS configuration for this gateway.
-- `listener` <code>(array<[listener]> : required)</code> - One or more listeners that the
+- `listener` <code>(array&lt;[listener]&gt; : required)</code> - One or more listeners that the
   ingress gateway should setup, uniquely identified by their port number.
 - `meta` `(map<string|string>: nil)` - Specifies arbitrary KV metadata pairs.
 - `defaults` `(IngressServiceConfig: <optional>)` - Default configuration that applies to all upstreams.

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -150,6 +150,8 @@ envoy_gateway_bind_addresses "<service>" {
 
 ### `terminating` Parameters
 
+- `meta` <code>(map<string|string>: nil)</code> - Specifies arbitrary KV metadata pairs.
+
 - `service` <code>(array<[linked-service]>: required)</code> - One or more services to be
   linked with the gateway. The gateway will proxy traffic to these services. These
   linked services must be registered with Consul for the gateway to discover their

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -152,33 +152,33 @@ envoy_gateway_bind_addresses "<service>" {
 - `service` <code>(array<[service]>: required)</code> - One or more services to be
   exposed via this listener. For `tcp` listeners, only a single service is allowed.
 
-- [`tls`][tls] `(TLSConfig: <optional>)` - TLS configuration for this listener.
+- [`tls`](#tls-parameters) `(TLSConfig: <optional>)` - TLS configuration for this listener.
 
-  - [`enabled`][enabled] `(bool: false)` - Set this configuration to true to enable built-in TLS for this listener.
+  - [`enabled`](#enabled) `(bool: false)` - Set this configuration to true to enable built-in TLS for this listener.
   If TLS is enabled, then each host defined in each service's Hosts field will be added as a DNSSAN
   to the gateway's x509 certificate. Note that even hosts from other listeners with TLS disabled will be added. 
   TLS can not be disabled for individual listeners if it is enabled on the gateway.
 
-- [`tls_min_version`][tls_min_version] `(string: "")` - Set the default minimum TLS version
-  supported for this listener. Refer to
-  [`TLSMinVersion`](/consul/docs/connect/config-entries/ingress-gateway#tlsminversion)
-  in the Consul documentation for supported versions.
+  - [`tls_min_version`](#tls_min_version) `(string: "")` - Set the default minimum TLS version
+    supported for this listener. Refer to
+    [`TLSMinVersion`](/consul/docs/connect/config-entries/ingress-gateway#tlsminversion)
+    in the Consul documentation for supported versions.
 
-- `tls_max_version` `(string: "")` - Set the default maximum TLS version
-  supported for this listener. Refer to
-  [`TLSMaxVersion`](/consul/docs/connect/config-entries/ingress-gateway#tlsmaxversion)
-  in the Consul documentation for supported versions.
+  - [`tls_max_version`](#tls_max_version) `(string: "")` - Set the default maximum TLS version
+    supported for this listener. Refer to
+    [`TLSMaxVersion`](/consul/docs/connect/config-entries/ingress-gateway#tlsmaxversion)
+    in the Consul documentation for supported versions.
 
-- `cipher_suites` `(array<string>: optional)` - Set the list of TLS cipher suites to support when negotiating
-  connections using TLS 1.2 or earlier. Refer to
-  [`CipherSuites`](/consul/docs/connect/config-entries/ingress-gateway#ciphersuites)
-  in the Consul documentation for the supported cipher suites.
+  - [`cipher_suites`](#cipher_suites) `(array<string>: optional)` - Set the list of TLS cipher suites to support when negotiating
+    connections using TLS 1.2 or earlier. Refer to
+    [`CipherSuites`](/consul/docs/connect/config-entries/ingress-gateway#ciphersuites)
+    in the Consul documentation for the supported cipher suites.
 
-  - [`sds`][sds] `(SDSConfig: <optional>)` - Defines a set of parameters that configures the listener to load TLS certificates from an external SDS service.
+    - [`sds`](#sds) `(SDSConfig: <optional>)` - Defines a set of parameters that configures the listener to load TLS certificates from an external SDS service.
 
-    - [`cluster_name`][cluster_name] `(string)` - The SDS cluster name to connect to to retrieve certificates.
+      - [`cluster_name`](#cluster_name) `(string)` - The SDS cluster name to connect to to retrieve certificates.
 
-    - [`cert_resource`][cert_resource] `(string)` - The SDS resource name to request when fetching the certificate from the SDS service.
+      - [`cert_resource`](#cert_resource) `(string)` - The SDS resource name to request when fetching the certificate from the SDS service.
 
 #### `service` Parameters
 
@@ -237,14 +237,14 @@ envoy_gateway_bind_addresses "<service>" {
   will be applied to responses from this service. This cannot be used with a tcp listener.
 - [`tls`][tls] `(ServiceTLSConfig: <optional>)` - TLS configuration for this service.
 
-  - [`sds`][sds] `(SDSConfig: <optional>)` - Defines a set of parameters that configures the SDS source 
+  - [`sds`](#sds) `(SDSConfig: <optional>)` - Defines a set of parameters that configures the SDS source 
   for the certificate for this specific service. At least one custom host must be specified in Hosts. 
   The certificate retrieved from SDS will be served for all requests identifying one of the Hosts values 
   in the TLS Server Name Indication (SNI) header.
 
-    - [`cluster_name`][cluster_name] `(string)` - The SDS cluster name to connect to to retrieve certificates.
+    - [`cluster_name`](#cluster_name) `(string)` - The SDS cluster name to connect to to retrieve certificates.
 
-    - [`cert_resource`][cert_resource] `(string)` - The SDS resource name to request when fetching the certificate from the SDS service.
+    - [`cert_resource`](#cert_resource) `(string)` - The SDS resource name to request when fetching the certificate from the SDS service.
 - `max_connections` `(int: 0)` - overrides for the Defaults field
 - `max_pending_requests` `(int: 0)` - overrides for the Defaults field
 - `max_concurrent_requests` `(int: 0)` - overrides for the Defaults field

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -114,6 +114,16 @@ envoy_gateway_bind_addresses "<service>" {
   [`CipherSuites`](/consul/docs/connect/config-entries/ingress-gateway#ciphersuites)
   in the Consul documentation for the supported cipher suites.
 
+- `sds` `(SDSConfig: <optional>)` - Defines a set of parameters that configures the gateway to load
+  TLS certificates from an external SDS service.
+
+    - `cluster_name` `(string)` - Specifies the name of the SDS cluster from which Consul should retrieve certificates.
+    This cluster must be specified in the Gateway's bootstrap configuration.
+
+    - `cert_resource` `(string)` - Specifies an SDS resource name. Consul will request the SDS resource name when
+    fetching the certificate from the SDS service. Setting this causes all listeners to be served exclusively over
+    TLS with this certificate unless overridden by listener-specific TLS configuration.
+
 #### `listener` Parameters
 
 - `port` `(int: required)` - The port that the listener should receive traffic on.
@@ -182,16 +192,16 @@ envoy_gateway_bind_addresses "<service>" {
   will be applied to requests routed to this service. This cannot be used with a tcp listener.
 - `response_headers` `(HTTPHeaderModifiers: <optional>)` - A set of HTTP-specific header modification rules that 
   will be applied to responses from this service. This cannot be used with a tcp listener.
-- `tls` `(ServiceTLSConfig: <optional>)` - TLS configuration for this service.
+- [`tls`][tls] `(ServiceTLSConfig: <optional>)` - TLS configuration for this service.
 
-  - `sds` `(SDSConfig: <optional>)` - Defines a set of parameters that configures the SDS source 
+  - [`sds`][sds] `(SDSConfig: <optional>)` - Defines a set of parameters that configures the SDS source 
   for the certificate for this specific service. At least one custom host must be specified in Hosts. 
   The certificate retrieved from SDS will be served for all requests identifying one of the Hosts values 
   in the TLS Server Name Indication (SNI) header.
 
-    - `cluster_name` `(string)` - The SDS cluster name to connect to to retrieve certificates.
+    - [`cluster_name`][cluster_name] `(string)` - The SDS cluster name to connect to to retrieve certificates.
 
-    - `cert_resource` `(string)` - The SDS resource name to request when fetching the certificate from the SDS service.
+    - [`cert_resource`][cert_resource] `(string)` - The SDS resource name to request when fetching the certificate from the SDS service.
 - `max_connections` `(int: 0)` - overrides for the Defaults field
 - `max_pending_requests` `(int: 0)` - overrides for the Defaults field
 - `max_concurrent_requests` `(int: 0)` - overrides for the Defaults field

--- a/website/content/docs/job-specification/gateway.mdx
+++ b/website/content/docs/job-specification/gateway.mdx
@@ -137,6 +137,34 @@ envoy_gateway_bind_addresses "<service>" {
 - `service` <code>(array<[service]>: required)</code> - One or more services to be
   exposed via this listener. For `tcp` listeners, only a single service is allowed.
 
+- [`tls`][tls] `(TLSConfig: <optional>)` - TLS configuration for this listener.
+
+  - [`enabled`][enabled] `(bool: false)` - Set this configuration to true to enable built-in TLS for this listener.
+  If TLS is enabled, then each host defined in each service's Hosts field will be added as a DNSSAN
+  to the gateway's x509 certificate. Note that even hosts from other listeners with TLS disabled will be added. 
+  TLS can not be disabled for individual listeners if it is enabled on the gateway.
+
+- [`tls_min_version`][tls_min_version] `(string: "")` - Set the default minimum TLS version
+  supported for this listener. Refer to
+  [`TLSMinVersion`](/consul/docs/connect/config-entries/ingress-gateway#tlsminversion)
+  in the Consul documentation for supported versions.
+
+- `tls_max_version` `(string: "")` - Set the default maximum TLS version
+  supported for this listener. Refer to
+  [`TLSMaxVersion`](/consul/docs/connect/config-entries/ingress-gateway#tlsmaxversion)
+  in the Consul documentation for supported versions.
+
+- `cipher_suites` `(array<string>: optional)` - Set the list of TLS cipher suites to support when negotiating
+  connections using TLS 1.2 or earlier. Refer to
+  [`CipherSuites`](/consul/docs/connect/config-entries/ingress-gateway#ciphersuites)
+  in the Consul documentation for the supported cipher suites.
+
+  - [`sds`][sds] `(SDSConfig: <optional>)` - Defines a set of parameters that configures the listener to load TLS certificates from an external SDS service.
+
+    - [`cluster_name`][cluster_name] `(string)` - The SDS cluster name to connect to to retrieve certificates.
+
+    - [`cert_resource`][cert_resource] `(string)` - The SDS resource name to request when fetching the certificate from the SDS service.
+
 #### `service` Parameters
 
 - `name` `(string: required)` - The name of the service that should be exposed through

--- a/website/content/docs/job-specification/proxy.mdx
+++ b/website/content/docs/job-specification/proxy.mdx
@@ -63,6 +63,8 @@ job "countdash" {
 - `config` `(map: nil)` - Proxy configuration that is opaque to Nomad and
   passed directly to Consul. See [Consul Connect documentation](/consul/docs/connect/proxies/envoy#dynamic-configuration)
   for details. Keys and values support [runtime variable interpolation][interpolation].
+- `local_service_socket_path` `(string: nil)` - String value that specifies the path of a Unix domain
+  socket for connecting to the local application instance.
 
 ## `proxy` Examples
 

--- a/website/content/docs/job-specification/sidecar_service.mdx
+++ b/website/content/docs/job-specification/sidecar_service.mdx
@@ -57,6 +57,8 @@ job "countdash" {
 - `tags` <code>(array&lt;string&gt;: nil)</code> - Custom Consul service tags
   for the sidecar service.
 
+- `meta` <code>(map<string|string>: nil)</code> - Specifies arbitrary KV metadata pairs.
+
 ## `sidecar_service` Examples
 
 The following example is a minimal `sidecar_service` block with defaults
@@ -67,7 +69,7 @@ The following example is a minimal `sidecar_service` block with defaults
   }
 ```
 
-The following example includes specifying upstreams.
+The following example includes specifying upstreams and meta.
 
 ```hcl
    sidecar_service {
@@ -76,6 +78,9 @@ The following example includes specifying upstreams.
          destination_name = "count-api"
          local_bind_port = 8080
        }
+     }
+     meta {
+       "test-key" = "test-value"
      }
    }
 

--- a/website/content/docs/job-specification/sidecar_service.mdx
+++ b/website/content/docs/job-specification/sidecar_service.mdx
@@ -57,7 +57,7 @@ job "countdash" {
 - `tags` <code>(array&lt;string&gt;: nil)</code> - Custom Consul service tags
   for the sidecar service.
 
-- `meta` <code>(map<string|string>: nil)</code> - Specifies arbitrary KV metadata pairs.
+- `meta` <code>(map&lt;string|string&gt;: nil)</code> - Specifies arbitrary KV metadata pairs.
 
 ## `sidecar_service` Examples
 

--- a/website/content/docs/job-specification/upstreams.mdx
+++ b/website/content/docs/job-specification/upstreams.mdx
@@ -83,6 +83,7 @@ job "countdash" {
 
 - `destination_name` `(string: <required>)` - Name of the upstream service.
 - `destination_namespace` `(string: <required>)` - Name of the upstream Consul namespace.
+- `destination_peer` `(string: "")` - Name of the name of the peer cluster containing the upstream service.
 - `local_bind_port` - `(int: <required>)` - The port the proxy will receive
   connections for the upstream on.
 - `datacenter` `(string: "")` - The Consul datacenter in which to issue the
@@ -90,6 +91,9 @@ job "countdash" {
   local Consul datacenter.
 - `local_bind_address` - `(string: "")` - The address the proxy will receive
   connections for the upstream on.
+- `local_bind_socket_path` - `(string: "")` - The path at which to bind a Unix domain socket listener.
+- `local_bind_socket_mode` - `(string: "")` - Unix octal that configures file permissions for the socket.
+- `destination_type` - `(string: "service")` - The type of discovery query the proxy should use for finding service mesh instances. 
 - `mesh_gateway` <code>([mesh_gateway][mesh_gateway_param]: nil)</code> - Configures the mesh gateway
   behavior for connecting to this upstream.
 - `config` `(map: nil)` - Upstream configuration that is opaque to Nomad and passed


### PR DESCRIPTION
Updated documentation for the following structs:
- ConsulTerminatingConfigEntry
- ConsulExpose 
- ConsulUpstream
- ConsulIngressConfigEntry
- ConsulProxy
- ConsulSidecarService 
- ConsulIngressListener
- ConsulIngressService
- ConsulGatewayTLSConfig
- ConsulLinkedService